### PR TITLE
Cambio en la alerta que indica que no se puede dar el vuelto

### DIFF
--- a/examen2_b98410/src/Utils/ErrorAlert.js
+++ b/examen2_b98410/src/Utils/ErrorAlert.js
@@ -15,7 +15,7 @@ export const changeErrorAlert = () => {
     Swal.fire({
       icon: 'warning',
       title: 'Oops...',
-      text: `¡No hay sufucientes monedas para darte el cambio!`
+      text: `Fallo al realizar la compra`
     })
   )
 }


### PR DESCRIPTION
Pull requests, con un cambio en la alerta que indica que no se puede dar el vuelto debido a la falta de monedas